### PR TITLE
use getattr instaed of vars for easier faking of args

### DIFF
--- a/aegea/batch.py
+++ b/aegea/batch.py
@@ -192,7 +192,7 @@ def get_command_and_env(args):
 def ensure_job_definition(args):
     if args.ecs_image:
         args.image = get_ecr_image_uri(args.ecs_image)
-    container_props = {k: vars(args)[k] for k in ("image", "vcpus", "memory", "privileged")}
+    container_props = {k: getattr(args, k) for k in ("image", "vcpus", "memory", "privileged")}
     if args.volumes:
         container_props.update(volumes=[], mountPoints=[])
         for i, (host_path, guest_path) in enumerate(args.volumes):


### PR DESCRIPTION
I am using aegea from python and I have an AegeaArgs object to emulate the args passed around in batch.py. This change makes it easier to implement an args that works.