### PR TITLE
MUTT 68 - Cryptic Aegea SSH failure

### DIFF
--- a/aegea/build_ami.py
+++ b/aegea/build_ami.py
@@ -29,13 +29,16 @@ def build_ami(args):
         launch_args.iam_role = None
         launch_args.cloud_config_data.update(rootfs_skel_dirs=args.rootfs_skel_dirs)
         instance = resources.ec2.Instance(launch(launch_args)["instance_id"])
+    ci_timeout = args.cloud_init_timeout
+    if ci_timeout <= 0:
+        ci_timeout = 99999
     ssh_client = AegeaSSHClient()
     ssh_client.load_system_host_keys()
     ssh_client.connect(instance.public_dns_name, username="ubuntu", key_filename=get_ssh_key_path(ssh_key_name))
-    sys.stderr.write("Waiting for cloud-init...")
+    sys.stderr.write("Waiting %d seconds for cloud-init..." % ci_timeout)
     sys.stderr.flush()
     devnull = open(os.devnull, "w")
-    for i in range(900):
+    for i in range(ci_timeout):
         try:
             ssh_client.check_output("ls /var/lib/cloud/data/result.json", stderr=devnull)
             res = ssh_client.check_output("sudo jq .v1.errors /var/lib/cloud/data/result.json", stderr=devnull)
@@ -85,3 +88,5 @@ parser.add_argument("--base-ami-product",
 parser.add_argument("--dry-run", "--dryrun", action="store_true")
 parser.add_argument("--tags", nargs="+", default=[], metavar="NAME=VALUE", help="Tag the resulting AMI with these tags")
 parser.add_argument("--cloud-config-data", type=json.loads)
+parser.add_argument("--cloud-init-timeout", type=int, default=-1,
+                    help="Approximate time in seconds to wait for cloud-init to finish before aborting.")

--- a/aegea/rootfs.skel/lib/systemd/system/efs.service
+++ b/aegea/rootfs.skel/lib/systemd/system/efs.service
@@ -6,7 +6,7 @@ Environment=AWS_CONFIG_FILE=/etc/aws.conf
 ExecStart=/usr/bin/aegea-efs-mount
 StandardOutput=syslog
 Restart=on-failure
-RestartSec=20
+RestartSec=60
 
 [Install]
 WantedBy=remote-fs.target

--- a/aegea/rootfs.skel/usr/bin/aegea-efs-mount
+++ b/aegea/rootfs.skel/usr/bin/aegea-efs-mount
@@ -39,7 +39,12 @@ for mountpoint, filesystem in mountpoints.items():
                                                         fs=filesystem["FileSystemId"],
                                                         region=efs.meta.region_name,
                                                         domain=services_domain)
-    mount_procs[mountpoint] = subprocess.Popen(["mount", "-t", "nfs4", fs_url, mountpoint])
+    # JHB: Changed to the following defaults.
+    mount_procs[mountpoint] = subprocess.Popen(
+        ["mount", "-t", "nfs4", "-o",
+         "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2",
+         fs_url, mountpoint]
+    )
 
 for m, p in mount_procs.items():
     if not os.path.isdir(m):

--- a/aegea/ssh.py
+++ b/aegea/ssh.py
@@ -15,23 +15,52 @@ MITM vulnerability.
 import os, sys, argparse, subprocess
 
 from . import register_parser
-from .util.aws import resolve_instance_id, resources
+from .util.aws import resolve_instance_id, resources, clients
 from .util.crypto import add_ssh_host_key_to_known_hosts
 from .util.printing import BOLD
 from .util.exceptions import AegeaException
 
+def check_for_active_ssh_key():
+    '''
+    Checks that there's an active SSH key, otherwise invocation will cryptically fail.
+
+    Raises AegeaException if no active key is found.
+    '''
+
+    # FIXME: This just raises an informative exception.
+    #        Howevever if there's no SSH access found, one could try to upload an SSH key
+    #        automagically for the user as done in aegea/util/crypto.py's ensure_ssh_key()
+    #        The relevant functions would be:
+    #           clients.iam.upload_ssh_public_key
+    #           clients.iam.update_ssh_public_key
+    #        See: http://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.upload_ssh_public_key
+    username = resources.iam.CurrentUser().user.name
+    ssh_pub_keys = clients.iam.list_ssh_public_keys(UserName=username)
+    has_valid_key = False
+    if 'SSHPublicKeys' in ssh_pub_keys:
+        for pub_key in ssh_pub_keys['SSHPublicKeys']:
+            if pub_key['Status'] == 'Active':
+                has_valid_key = True
+                break
+    if not has_valid_key:
+        raise AegeaException("Current IAM user: \"%s\" doesn't have an active AWS CodeCommit SSH key."%username)
+
 def ssh(args):
+    check_for_active_ssh_key()
+
     prefix, at, name = args.name.rpartition("@")
     instance = resources.ec2.Instance(resolve_instance_id(name))
     if not instance.public_dns_name:
         msg = "Unable to resolve public DNS name for {} (state: {})"
         raise AegeaException(msg.format(instance, getattr(instance, "state", {}).get("Name")))
+
     tags = {tag["Key"]: tag["Value"] for tag in instance.tags or []}
     ssh_host_key = tags.get("SSHHostPublicKeyPart1", "") + tags.get("SSHHostPublicKeyPart2", "")
     if ssh_host_key:
         # FIXME: this results in duplicates.
         # Use paramiko to detect if the key is already listed and not insert it then (or only insert if different)
         add_ssh_host_key_to_known_hosts(instance.public_dns_name + " " + ssh_host_key + "\n")
+
     ssh_args = ["ssh", prefix + at + instance.public_dns_name] + args.ssh_args
     os.execvp("ssh", ssh_args)
 


### PR DESCRIPTION
Here's one approach at addressing this. It just checks the SSH key status and throws an exception if there isn't at least one active.

As noted in the comments in the commit, the more aegea-like thing to do would be automating creation of that SSH key if it doesn't exist.

@extemporaneousb can you review?