### PR TITLE
batch submit --execute: Follow s3 redirects for staging bucket url

### DIFF
--- a/aegea/util/aws/batch.py
+++ b/aegea/util/aws/batch.py
@@ -112,7 +112,7 @@ def get_command_and_env(args):
         shellcode += ['BATCH_SCRIPT=$(mktemp --tmpdir "{tmpdir_fmt}")'.format(tmpdir_fmt=tmpdir_fmt),
                       "apt-get update -qq",
                       "apt-get install -qqy --no-install-suggests --no-install-recommends curl ca-certificates gnupg",
-                      "curl '{payload_url}' > $BATCH_SCRIPT".format(payload_url=payload_url),
+                      "curl -L '{payload_url}' > $BATCH_SCRIPT".format(payload_url=payload_url),
                       "chmod +x $BATCH_SCRIPT",
                       "$BATCH_SCRIPT"]
     elif args.cwl:


### PR DESCRIPTION
s3 sometimes sends this 307 response for pre-signed urls to non-regional bucket endpoints:

```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>TemporaryRedirect</Code><Message>Please re-send this request to the specified temporary endpoint. Continue to use the original request endpoint for future requests.</Message><Endpoint>aegea-ecs-execute-prod.s3-us-west-2.amazonaws.com</Endpoint><Bucket>aegea-ecs-execute-prod</Bucket>...</Error>
```