### PR TITLE
Print the command that would be run with aegea batch --dry-run

### DIFF
--- a/aegea/batch.py
+++ b/aegea/batch.py
@@ -189,6 +189,7 @@ def submit(args):
                        parameters={k: v for k, v in args.parameters},
                        containerOverrides=container_overrides)
     if args.dry_run:
+        print("The following command would be run: {0}".format(submit_args))
         return {"Dry run succeeded": True}
     try:
         job = clients.batch.submit_job(**submit_args)


### PR DESCRIPTION
Aegea does some path manipulation before submitting jobs to batch. This allows the user to see the actual command that is being send to aws including all of that stuff.