### PR TITLE
Use distro package if available in ssm.py for Python 3.8 compatibility

### DIFF
--- a/aegea/util/aws/ssm.py
+++ b/aegea/util/aws/ssm.py
@@ -4,6 +4,13 @@ import os, sys, io, stat, shutil, platform, subprocess, tempfile, zipfile, time
 
 import boto3
 
+using_distro = False
+try:
+    import distro
+    using_distro = True
+except ImportError:
+    pass
+
 from ... import logger, config
 from .. import Timestamp
 from ..exceptions import AegeaException
@@ -44,7 +51,9 @@ def ensure_session_manager_plugin():
         target_path = os.path.join(session_manager_dir, "session-manager-plugin")
         if platform.system() == "Darwin":
             download_session_manager_plugin_macos(target_path=target_path)
-        elif platform.linux_distribution()[0] == "Ubuntu":  # type: ignore
+        elif using_distro and distro.id() == "ubuntu":
+            download_session_manager_plugin_linux(target_path=target_path)
+        elif not using_distro and platform.linux_distribution()[0] == "Ubuntu":  # type: ignore
             download_session_manager_plugin_linux(target_path=target_path)
         else:
             download_session_manager_plugin_linux(target_path=target_path, pkg_format="rpm")

--- a/aegea/util/aws/ssm.py
+++ b/aegea/util/aws/ssm.py
@@ -4,13 +4,6 @@ import os, sys, io, stat, shutil, platform, subprocess, tempfile, zipfile, time
 
 import boto3
 
-using_distro = False
-try:
-    import distro
-    using_distro = True
-except ImportError:
-    pass
-
 from ... import logger, config
 from .. import Timestamp
 from ..exceptions import AegeaException
@@ -51,9 +44,7 @@ def ensure_session_manager_plugin():
         target_path = os.path.join(session_manager_dir, "session-manager-plugin")
         if platform.system() == "Darwin":
             download_session_manager_plugin_macos(target_path=target_path)
-        elif using_distro and distro.id() == "ubuntu":
-            download_session_manager_plugin_linux(target_path=target_path)
-        elif not using_distro and platform.linux_distribution()[0] == "Ubuntu":  # type: ignore
+        elif "Ubuntu" in subprocess.run(["uname", "-a"], capture_output=True).stdout.decode():  # type: ignore
             download_session_manager_plugin_linux(target_path=target_path)
         else:
             download_session_manager_plugin_linux(target_path=target_path, pkg_format="rpm")


### PR DESCRIPTION
Python 3.8 removed the `platform.linux_distribution()` method used in `ssm.py`, causing an error when trying to use aegea on Linux. This PR adds the recommended replacement module `distro` and uses it to check if the user is running Ubuntu, falling back to the old behavior if `distro` was not successfully imported.